### PR TITLE
Fix typo in title

### DIFF
--- a/docs/admin/runai-setup/cluster-setup/install-k8s.md
+++ b/docs/admin/runai-setup/cluster-setup/install-k8s.md
@@ -1,4 +1,4 @@
-# Native Kubeneretes Installation
+# Native Kubernetes Installation
 
 Kubernetes is composed of master(s) and workers. The instructions below are for creating a bare-bones installation of a single master and several workers for __testing__ purposes. For a more complex, __production-grade__, Kubernetes installation, use tools such as _Kubespray_ [https://kubespray.io/](https://kubespray.io/#/){target=_blank}, Rancher Kubernetes Engine or review [Kubernetes documentation](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/){target=_blank} to learn how to customize the native installation.
 


### PR DESCRIPTION
Correcting a misspelling in the title of the page.

"Oh, the venerated Kubeneretes. How mysterious and unknowable."