### PR TITLE
Fix: Failed to emphasize the code block

### DIFF
--- a/docs/Researcher/Walkthroughs/walkthrough-overquota.md
+++ b/docs/Researcher/Walkthroughs/walkthrough-overquota.md
@@ -52,7 +52,8 @@ Run the following command:
 
 _a1_ is now going to start running again.
 
-Run: 
+Run:
+
     runai list jobs -A
 
 You have __two__ Jobs that are running on the first node and __one__ Job that is running alone the second node. 


### PR DESCRIPTION
This patch fixes the [doc](https://docs.run.ai/Researcher/Walkthroughs/walkthrough-overquota/#part-3-bin-packing) which does not emphasize the code block.