### PR TITLE
fix/rename-helm-delete

### DIFF
--- a/docs/admin/runai-setup/cluster-setup/cluster-delete.md
+++ b/docs/admin/runai-setup/cluster-setup/cluster-delete.md
@@ -7,20 +7,20 @@ To delete a Run:ai Cluster installation while retaining existing running jobs, r
 
 === "Version 2.9 or later"
     ```
-    helm delete runai-cluster -n runai
+    helm uninstall runai-cluster -n runai
     ``` 
 
 === "Version 2.8"
     ```
     kubectl delete RunaiConfig runai -n runai
-    helm delete runai-cluster -n runai
+    helm uninstall runai-cluster -n runai
     ```
 
 === "Version 2.7 or earlier"
     ```
     kubectl patch RunaiConfig runai -n runai -p '{"metadata":{"finalizers":[]}}' --type="merge"
     kubectl delete RunaiConfig runai -n runai
-    helm delete runai-cluster runai -n runai
+    helm uninstall runai-cluster runai -n runai
     ```
 
 The commands will __not__ delete existing Jobs submitted by users. 

--- a/docs/admin/runai-setup/self-hosted/k8s/uninstall.md
+++ b/docs/admin/runai-setup/self-hosted/k8s/uninstall.md
@@ -13,7 +13,7 @@ To uninstall the cluster see: [cluster delete](../../cluster-setup/cluster-delet
 To delete the control plane, run:
 
 ``` shell
-helm delete runai-backend -n runai-backend
+helm uninstall runai-backend -n runai-backend
 
 ```
 


### PR DESCRIPTION
According to Helm's official [docs](https://helm.sh/docs/helm/helm_delete/), the `helm delete` command has been replaced with `helm uninstall`.