### PR TITLE
Aditional step for researcher authentication on GKE

### DIFF
--- a/docs/admin/runai-setup/authentication/researcher-authentication.md
+++ b/docs/admin/runai-setup/authentication/researcher-authentication.md
@@ -106,6 +106,20 @@ Modifying the API Server configuration differs between Kubernetes distributions:
 
     Where the `OIDC` flags are provided in the Run:ai server configuration section as described above. 
 
+    Then update runaiconfig with  the Anthos endpoint - gke-oidc-envoy.
+    Get the externel IP of the service in the Anthos namespace.
+
+    ```
+    kubectl get svc -n anthos-identity-service
+    NAME               TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)              AGE
+    gke-oidc-envoy     LoadBalancer   10.37.3.111   39.201.319.10   443:31545/TCP        12h
+    ```
+
+    Add the IP to runaiconfig 
+
+    ```
+    kubectl -n runai patch runaiconfig runai -p '{"spec": {"researcher-service": {"args": {"gkeOidcEnvoyHost": "35.236.229.19"}}}}'  --type="merge"
+    ```
 
     To create a kubeconfig profile for Researchers run:
 


### PR DESCRIPTION
Adding the envoy host IP to runaiconfig.