### PR TITLE
shaibi/support custom ca on openshift

### DIFF
--- a/docs/admin/runai-setup/config/org-cert.md
+++ b/docs/admin/runai-setup/config/org-cert.md
@@ -29,13 +29,19 @@ kubectl -n runai-backend create secret generic runai-ca-cert \
 
 ## Cluster Installation
 
-* Create the `runai` namespace if it does not exist. 
-* Add the public key to the `runai` namespace:
-```
-kubectl -n runai create secret generic runai-ca-cert \
-    --from-file=runai-ca.pem=<ca_bundle_path>
-```
-
+=== "Non-Openshift"
+    * Create the `runai` namespace if it does not exist. 
+    * Add the public key to the `runai` namespace:
+    ```
+    kubectl -n runai create secret generic runai-ca-cert \
+        --from-file=runai-ca.pem=<ca_bundle_path>
+    ```
+=== "Openshift"
+    * Add the public key to the `openshift-monitoring` namespace:
+    ```
+    kubectl -n openshift-monitoring create secret generic runai-ca-cert \
+        --from-file=runai-ca.pem=<ca_bundle_path>
+    ```
 * Install the Run:ai operator, add the following flag to the helm command `--set global.customCA.enabled=true`
 
 


### PR DESCRIPTION
- Fixed table issue for HF
- Fixed submit-dist missing info in a note
- Update allow-external-access-to-containers.md
- remove-stuff-related-to-28-29
- spelling mistake
- changed headings
- Update walkthrough-distributed-training.md
- helm-upgrade-cluster-instructions
- helm-upgrade-cluster-instructions
- Update cluster-upgrade.md
- remove rke2 incorrect instructions
- rke2-bug-fix
- fixed spelling and grammar
- helm-310-or-later
- get-jobs-example
- default-storage-class-sample
- default-storage-class-sample
- sso-changes
- researcher-auth-for-sso
- [RUN-10087] add email notification to docs
- Apply suggestions from code review
- Update docs/admin/researcher-setup/email-messaging.md
- Apply suggestions from code review
- Added Gal's changes
- add new message table
- moved the tip
- comment out message table
- markdown corrections
- Update mkdocs.yml (#455)
- moved try azure to graveyard
- .
- updated
- Fixed grammar and MD
- update link
- update link
- large-cluster-config
- psa update 2.13
- Update cluster-prerequisites.md
- New branch
- space added
- psa update 2.13
- custom-env-in ocp
- custom-env-in ocp
- remove ocp-first-user-in-2-13 and up
- updated whats new
- remove ocp-first-user-in-2-13 and up
- reaplce 2.14 to 2.15 and other bugs
- penn-upgrade-retrospective
- updated whats new
- penn-upgrade-retrospective
- update alertmanager documentations for health
- Update docs/admin/runai-setup/maintenance/alert-monitoring.md
- Updated markdown alert-monitoring
- Updated markdown alert-monitoring
- changes according to Snir
- fixed note location
- update metrics tables
- cli correction
- airgapped-package-name-on-ocp
- resolve-conflict
- conflict resolutions
- v215-cluster-installation
- v215-cluster-installation
- v215-cluster-installation
- v215-cluster-installation
- psa-message
- os-k8s-support
- k8s-support
- Update cluster-prerequisites.md
- [RUN-10221] add csv download to all grid features
- changed description
- added dgx changes
- another change
- added run-10271 description
- [RUN-10271] add configuration to procedure
- [RUN-10404] add distributed training procedure
- added description to RUN-10404
- added description to RUN-10622
- [RUN-10622] add prevent data store on node
- added descriptions
- add description to run-11292
- [RUN-11292] update more settings
- added description to RUN-11692
- [RUN-11692] add template file with scope
- cert-auth-draft-and-no-researcher-auth
- added RUN-10639 description
- edited RUN-10639 description
- added snippet refs from 2.14
- add description RUN-9808
- RUN-11949 add cluster migration script
- added ref to link in 9808
- added missing tickets
- add todo labels for open doc tasks
- added description for multiple todos
- RUN-12872 add workloads view to workloads page
- removed integrations into graveyard
- add description to run 10251
- RUN-10252 add block over quota to scheduler
- small changes
- Update docs/admin/workloads/workload-overview-admin.md
- RUN-12872 add explanation
- RUN-12872 MD cleanup
- added link
- RUN-10252 added comments
- changed link
- todo with need links
- changed to ADDLINK
- Update cluster-prerequisites.md
- add cpu dashboards description
- RUN-12314 add CPU dashboards to file
- added link to cpu dashboard
- RUN-12314 add text to CPU dashboard section
- added link to pre-reqs
- RUN-10625 changed according to Ofer
- Apply suggestions from code review
- Update docs/Researcher/scheduling/the-runai-scheduler.md
- Update docs/Researcher/scheduling/the-runai-scheduler.md
- Apply suggestions from code review
- RUN-10252 - change block to limit
- RUN-10252 change section heading
- changed link in 10252
- small change in a description
- RUN-12314 change jobs to workloads
- RUN-12314 remove images GPU dashboard specific
- RUN-12872 remove note and add submit
- added run-12235
- RUN-10863 reorg and update secrets for scope
- RUN-10863 correction in files and reorg
- changed link in 10863
- local-certificate-authority-updates
- local-certificate-authority-updates
- local-certificate-authority-updates-and-knative-version
- removed 9808 policy button
- Apply suggestions from code review
- RUN-11747 update for workers settings md correction
- added to air gap description
- added dist training for env
- RUN-11240 add to procedure for create env
- RUN-11240 fixed md issues
- md corrections
- RUN-11747 - added RUN-11242 line 41 with note
- RUN-11694 add more explanation
- RUN-11694 md correction
- RUN-12176 add node status table to node pool page
- RUN-12176 fixed MD
- RUN12176 fixed another MD
- added node status link
- todo list cleanup and link to time slicing
- RUN-9925 grammar edits
- RUN-10241 added workspace
- added training
- added workers and master diff config
- corrected training to workers and master diff setup
- correction
- RUN-9925 add gpu-time-slice file with images
- Add info and link to custom cluster install
- RUN-9925 update image
- fix/rename-helm-delete
- mpi-is-different
- Update customize-cluster-install.md
- Update customize-cluster-install.md
- Update docs/home/whats-new-2-15.md
- Update docs/home/whats-new-2-15.md
- MD and conflict adjustment
- helm-syntax-self-hosted-airgaped
- some changes
- updated-arch-pic
- RUN-10603 add description
- RUN-9925 correct based on Hagay comment
- RUN-12235 suggestions based on comments
- RUN-11692 changed based on comments
- corrections based on comments
- added link to trainings x-ref to templates
- add and correct based on comments
- add whats new links corrections FM and rbac correction
- RUN-11949 fixed operator-helm-vals-diff.sh
- docs update for staging
- rbac corrections
- grammar
- remove-212-k8s
- RUN-13469 update CRD files explanation
- upgrade-cluster-airgapped
- upgrade-cluster-airgapped
- psa
- mpi-training-operator-version-clarification
- mpi-training-operator-version-clarification
- reference-local-certificate
- update based on yaron comments
- new-components-page
- Update docs/home/components.md
- Update docs/home/components.md
- Update docs/home/components.md
- Apply suggestions from code review
- new-diagram
- installation-types-diagram
- typo
- mpi-fix-by-Itay
- airgapped-images-flag
- airgapped-images-flag
- airgapped-images-flag
- airgapped-images-flag
- restrict-node-scheduling
- restrict-node-scheduling
- changes to what's new
- fix relative links
- V2.15-run-10603-dynamic-gpu-fractions (#548)
- fix integration links
- RUN-13168 add description of over-quota priority disabled behavior
- fixes
- changes from Hagay
- Update docs/Researcher/scheduling/the-runai-scheduler.md
- RUN-13168 add description of over-quota priority disabled behavior (#557)
- bright-limit
- bright-limit
- Update refs to 2.17 branch
- change copyright date
- dr-ha-docker-registry
- Update credentials-setup.md
- dor-review
- Update docs/admin/runai-setup/config/ha.md
- Update docs/admin/runai-setup/config/ha.md
- Update docs/admin/runai-setup/config/ha.md
- Update docs/admin/runai-setup/config/ha.md
- Update docs/admin/runai-setup/config/ha.md
- Update docs/admin/runai-setup/config/large-clusters.md
- dor-comments
- dor-comments
- Update credentials-setup.md
- dor-comments
- dor-comments
- remove registry integration doc from TOC
- fixed MD errors
- fixed MD038 errors in tabs
- add markdownlint ignore file
- dor-kirzon-feedback
- Update whats-new-2-15.md
- vale reconfig
- Update docs/admin/runai-setup/config/dr.md
- linting and other updates
- RBAC adjustment
- Update whats-new-2-15.md
- Update mkdocs.yml
- Fixed based on comments
- RUN-14039 added whats new file
- updated RNs for 2.15
- Whats-new update remove email config. file move to graveyard
- remove old RN file
- add release content from jira
- updated RNs for 2.15
- Whats-new update remove email config. file move to graveyard
- remove old RN file
- corrections and add titles
- organize tickets
- add features to test
- Merge pull request #579 from tailoralex/patch-3
- Merge pull request #579 from tailoralex/patch-3
- switch to 2.16
- change to 2.16
- changed to 2.16
- cleanup of list
- typo
- nvidia-input
- Update docs/developer/rest-auth.md
- Apply suggestions from code review
- Merge pull request #589 from run-ai/auth-python-revamp
- curl-python-tabs
- RUN-11125 adding tables and API render
- Merge pull request #591 from run-ai/no-tabs
- Update mkdocs.yml
- RUN-14039 add descriptions and sync todo list
- RUN-11125 policy update
- RUN-11125 small corrections
- RUN-11125 remove swagger plugin
- add-spec
- RUN-14039 cleanup epics no docs needed
- RUN-11125 relocate some files
- RUN-14039 update list
- Update cluster-prerequisites.md
- RUN-11125 add API ref page to left TOC.
- Update cluster-prerequisites.md
- Merge pull request #576 from tailoralex/patch-2
- RUN-11125 move files to new location
- prom-size
- prom-size
- Revert "bright-limit"
- RUN-11125 update files
- RUN-14039 list cleanup
- RUN-14039 update list
- RUN-14309 update file
- RUN-14703 add column and info
- RUN-14703 add to projects and departments tables
- RUN-14039 addlink added
- RUN-14703 style corrections
- RUN-13299 add configure admin message procedure
- RUN-14039 add link to admin messages
- RUN-14039 add link
- RUN-12601 add private toggle and other changes
- RUN-14039 add changes
- RUN-11125 update content
- RUN-14041 new workloads file - no mkdocs.yml set
- RUN-14041 add new submit file
- Kubernetes-updated
- RUN-14039 add GPU health info
- RUN-14155 add indicators for GPU CPU
- RUN-14115 add GPU and CPU graph to dashboard
- privacy-policy-and-control-plane-api
- RUN-14039 Changes
- RUN-14039 add SSO user description
- RUN-13108 add visibility and creation
- RUN-11951 update cluster status and tables
- RUN-11951 add table and statuses
- Apply suggestions from code review
- RUN-11125 add workspace YAML fields - no english correction
- RUN-11125 add policy snippets file
- RUN-11125 add sections on training
- RUN-11125 remove H7 tags
- Apply suggestions from code review
- Apply suggestions from code review
- RUN-14041 change filename to readme
- Changed MKDocs YAML to fit readme in topic
- RUN-14039 add link to workloads page
- RUN-14039 add link to present policy in project
- RUN-10860 add view policy to project page
- RUN-10860 spelling
- RUN-14039 add link to project view policy
- RUN-14039 add link to pre-reqs
- Update links
- RUN-11125 remove API policy page and JSON file
- Remove policy API pages from developer menu
- RUN-11125 updated file
- Update whats-new-2-16.md
- Update README.md
- Update whats-new-2-16.md
- Corrections from Alon
- Add changes and addtions
- update with Alon changes
- RUN-13108 some of Gal changes
- RUN-13108 corrections from Gal
- RN cleanup and other corrections
- Apply suggestions from code review
- Added changes
- no-docker-for-windows
- rename bright to BCM
- rename bright to BCM
- rename native kubernetes to vanilla
- rename bright to BCM
- rename native to vanilla kubernetes
- rename native to vanilla
- changesRUN_1512 add files and content
- RUN-15152 add corrections to files
- Lior's changes
- Changes from Lior.
- Apply suggestions from code review
- RUN-15152 fix link
- Update RunaiAgentClusterInfoPushRateLow.md
- Update RunaiAgentPullRateLow.md
- Update RunaiContainerRestarting.md
- Update RunaiCriticalProblem.md
- Update RunaiDaemonSetRolloutStuck.md
- Update RunaiDaemonSetUnavailableOnNodes.md
- Update RunaiDeploymentInsufficientReplicas.md
- Update RunaiDeploymentNoAvailableReplicas.md
- Update RunaiDeploymentUnavailableReplicas.md
- Update RunaiProjectControllerReconcileFailure.md
- corrections
- Update PSA support
- Update cluster-health-check.md
- Apply suggestions from code review
- Update cluster-health-check.md
- Update docs/admin/troubleshooting/cluster-health-check.md
- Update docs/admin/troubleshooting/cluster-health-check.md
- Update docs/admin/troubleshooting/cluster-health-check.md
- Update docs/admin/troubleshooting/cluster-health-check.md
- Update docs/admin/troubleshooting/cluster-health-check.md
- Update docs/admin/troubleshooting/cluster-health-check.md
- Update docs/admin/troubleshooting/cluster-health-check.md
- Apply suggestions from code review
- RUN-13631 corrections and MD styling
- Update docs/admin/troubleshooting/cluster-health-check.md
- Gal's suggestions
- Update cluster-prerequisites.md
- Update cluster-health-check.md
- RUN-154757 add new default for workload
- Some fixes from Guy's comments
- Update docs/home/whats-new-2-16.md
- Updated the troubleshooting actions for disconnected cluster
- Update docs/home/whats-new-2-16.md
- Apply suggestions from code review
- Update docs/admin/troubleshooting/cluster-health-check.md
- .


[RUN-10087]: https://runai.atlassian.net/browse/RUN-10087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-10221]: https://runai.atlassian.net/browse/RUN-10221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ