### PR TITLE
fixed the "stop workload" example command

### DIFF
--- a/docs/developer/cluster-api/submit-rest.md
+++ b/docs/developer/cluster-api/submit-rest.md
@@ -52,9 +52,9 @@ To suspend or stop a workload run:
 ```bash
 curl -X PATCH \ # (1) 
 'https://<IP>:6443/apis/run.ai/v2alpha1/namespaces/<PROJECT>/interactiveworkload/<JOB-NAME>' \
-    --header 'Content-Type: application/json' 
-    --header 'Authorization: Bearer <TOKEN>'# (2) 
-    --data '{"spec":{"active": {"value": "false"}}}'
+    --header 'Content-Type: application/merge-patch+json' \
+    --header 'Authorization: Bearer <TOKEN>' \ # (2) 
+    --data '{"spec":{"active": {"value": false}}}'
 ```
 
 1. Replace `<IP>` with the Kubernetes control-plane endpoint (can be found in kubeconfig profile). <br> Replace `<PROJECT>` with the name of the Run:ai namespace for the specific Project (typically `runai-<Project-Name>`). <br> Replace `trainingworkloads` with `interactiveworkloads`, `distributedworkloads` or `inferenceworkloads` according to type. <br> Replace `<JOB-NAME>` with the name of the Job. 


### PR DESCRIPTION
with current example command, users get the following message:

```
"Failure","message":"the body of the request was in an unknown format - accepted media types include: application/json-patch+json, application/merge-patch+json, application/apply-patch+yaml","reason":"UnsupportedMediaType","code":415
```

the issues are:
1. content type
2. string value instead of boolean
