### PR TITLE
Update API deprecations for 2.17

### DIFF
--- a/docs/developer/overview-developer.md
+++ b/docs/developer/overview-developer.md
@@ -12,7 +12,7 @@ Developers can access Run:ai through various programmatic interfaces.
 
 The endpoints and parameters specified in the API reference are the ones that are officially supported by Run:ai. Endpoints and parameters that are **NOT** listed in the reference are not officially supported.
 
-API endpoints and fields marked as `deprecated` means they remain operational and can be used; however, Run:ai will **NO LONGER RECOMMEND USING THEM**, **WILL NOT ADD FUNCTIONALITY TO THEM**, and **WILL STOP SUPPORTING THEM** after 2 major releases (for self-hosted deployments), and after 6 months of support for SaaS deployments.
+API endpoints and fields marked as `deprecated` remain operational and can be used; however, Run:ai will **NO LONGER RECOMMEND USING THEM**, **WILL NOT ADD FUNCTIONALITY TO THEM**, and **WILL STOP SUPPORTING THEM** after 2 major releases (for self-hosted deployments), and after 6 months of support for SaaS deployments.
 
 For details, see the [Deprecation notifications](../home/whats-new-2-17.md#deprecation-notifications).
 

--- a/docs/developer/overview-developer.md
+++ b/docs/developer/overview-developer.md
@@ -12,10 +12,7 @@ Developers can access Run:ai through various programmatic interfaces.
 
 The endpoints and parameters specified in the API reference are the ones that are officially supported by Run:ai. Endpoints and parameters that are **NOT** listed in the reference are not officially supported.
 
-Endpoints and parameters marked as `deprecated` means they remain operational and can be used; however, Run:ai will **NO LONGER RECOMMEND USING THEM**, **WILL NOT ADD FUNCTIONALITY TO THEM**, and **WILL NO LONGER BE SUPPORTED AFTER**
-
-Option1 : <#of versions>
-Option 2: <time period>.
+API endpoints and fields marked as `deprecated` means they remain operational and can be used; however, Run:ai will **NO LONGER RECOMMEND USING THEM**, **WILL NOT ADD FUNCTIONALITY TO THEM**, and **WILL STOP SUPPORTING THEM** after 2 major releases (for self-hosted deployments), which are 6 months of support for SaaS deployments.
 
 For details, see the [Deprecation notifications](../home/whats-new-2-17.md#deprecation-notifications).
 

--- a/docs/developer/overview-developer.md
+++ b/docs/developer/overview-developer.md
@@ -12,7 +12,7 @@ Developers can access Run:ai through various programmatic interfaces.
 
 The endpoints and parameters specified in the API reference are the ones that are officially supported by Run:ai. Endpoints and parameters that are **NOT** listed in the reference are not officially supported.
 
-API endpoints and fields marked as `deprecated` means they remain operational and can be used; however, Run:ai will **NO LONGER RECOMMEND USING THEM**, **WILL NOT ADD FUNCTIONALITY TO THEM**, and **WILL STOP SUPPORTING THEM** after 2 major releases (for self-hosted deployments), which are 6 months of support for SaaS deployments.
+API endpoints and fields marked as `deprecated` means they remain operational and can be used; however, Run:ai will **NO LONGER RECOMMEND USING THEM**, **WILL NOT ADD FUNCTIONALITY TO THEM**, and **WILL STOP SUPPORTING THEM** after 2 major releases (for self-hosted deployments), and after 6 months of support for SaaS deployments.
 
 For details, see the [Deprecation notifications](../home/whats-new-2-17.md#deprecation-notifications).
 

--- a/docs/home/whats-new-2-17.md
+++ b/docs/home/whats-new-2-17.md
@@ -163,28 +163,28 @@ The following list of API endpoints and fields that have been marked for depreca
 | /v1/k8s/groups | /api/v1/authorization/access-rules |
 | /v1/k8s/groups/{groupName} | /api/v1/authorization/access-rules |
 | /v1/k8s/clusters/{clusterId}/departments/{department-id}/access-control | /api/v1/authorization/access-rules |
-| /api/v1/authorization/access-rules - _subjectIdFilter_ field | Use _filterBy_ / _sortBy_ fields |
-| /api/v1/authorization/access-rules - _scopeType_ field | Use _filterBy_ / _sortBy_ fields |
-| /api/v1/authorization/access-rules - _roleId_ field | Use _filterBy_ / _sortBy_ fields |
+| /api/v1/authorization/access-rules - `subjectIdFilter` field | Use `filterBy` / `sortBy` fields |
+| /api/v1/authorization/access-rules - `scopeType` field | Use `filterBy` / `sortBy` fields |
+| /api/v1/authorization/access-rules - `roleId` field | Use `filterBy` / `sortBy` fields |
 
 ##### Projects API
 
 | Deprecated | Replacement |
 | -- | -- |
-| /v1/k8s/clusters/{clusterId}/projects - _permissions_ field | /api/v1/authorization/access-rules |
-| /v1/k8s/clusters/{clusterId}/projects - _resources_ field | Use _nodePoolResources_ field |
-| /v1/k8s/clusters/{clusterId}/projects - _deservedGpus_ field | Use _nodePoolResources_ field |
-| /v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
-| /v1/k8s/clusters/{clusterId}/projects - _gpuOverQuotaWeight_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/projects - `permissions` field | /api/v1/authorization/access-rules |
+| /v1/k8s/clusters/{clusterId}/projects - `resources` field | Use `nodePoolResources` field |
+| /v1/k8s/clusters/{clusterId}/projects - `deservedGpus` field | Use `nodePoolResources` field |
+| /v1/k8s/clusters/{clusterId}/projects - `maxAllowedGpus` field | Use `nodePoolResources` field |
+| /v1/k8s/clusters/{clusterId}/projects - `gpuOverQuotaWeight` field | Use `nodePoolResources` field |
 
 ##### Departments API
 
 | Deprecated | Replacement |
 | -- | -- |
-| /v1/k8s/clusters/{clusterId}/departments - _resources_ field | Use _nodePoolResources_ field |
-| /v1/k8s/clusters/{clusterId}/departments - _deservedGpus_ field | Use _nodePoolResources_ field |
-| /v1/k8s/clusters/{clusterId}/departments - _allowOverQuota_ field | Use _nodePoolResources_ field |
-| /v1/k8s/clusters/{clusterId}/departments - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/departments - `resources` field | Use `nodePoolResources` field |
+| /v1/k8s/clusters/{clusterId}/departments - `deservedGpus` field | Use `nodePoolResources` field |
+| /v1/k8s/clusters/{clusterId}/departments - `allowOverQuota` field | Use `nodePoolResources` field |
+| /v1/k8s/clusters/{clusterId}/departments - `maxAllowedGpus` field | Use `nodePoolResources` field |
 
 ##### Policy API
 
@@ -201,13 +201,13 @@ The following list of API endpoints and fields that have completed their depreca
 
 | Endpoint | Change |
 | -- | -- |
-| /api/v1/asset/compute | _gpuRequest_ field was removed and is replaced by the following fields _gpuDevicesRequest_, _gpuRequestType_, _gpuPortionRequest_, _gpuPortionLimit_, _gpuMemoryRequest_, _gpuMemoryLimit_, _migProfile_ |
+| /api/v1/asset/compute | `gpuRequest` field was removed and is replaced by the following fields `gpuDevicesRequest`, `gpuRequestType`, `gpuPortionRequest`, `gpuPortionLimit`, `gpuMemoryRequest`, `gpuMemoryLimit`, `migProfile` |
 
 ### Metrics deprecations
 
 The following metrics are deprecated and replaced by API. For details about the replacement APIs, see [Changed Metrics](../developer/metrics/metrics.md#changed-metrics-and-api-mapping):
 
-| Metric | 
+| Metric |
 | -- |
 | runai\_active\_job\_cpu\_requested\_cores |
 | runai\_active\_job\_memory\_requested\_bytes |
@@ -220,7 +220,7 @@ The following metrics are deprecated and replaced by API. For details about the 
 | runai\_gpu\_memory\_used\_mebibytes\_per\_pod\_per\_gpu |
 | runai\_active\_job\_cpu\_limits |
 | runai\_job\_cpu\_usage |
-| runai\_active\_job\_memory\_limits |                                                                                       
+| runai\_active\_job\_memory\_limits |
 | runai\_job\_memory\_used\_bytes |
 
 ## Breaking changes

--- a/docs/home/whats-new-2-17.md
+++ b/docs/home/whats-new-2-17.md
@@ -128,9 +128,11 @@ Deprecated features will be available for **two** versions ahead of the notifica
 
 The endpoints and parameters specified in the API reference are the ones that are officially supported by Run:ai. For more information about Run:ai's API support policy and deprecation process, see [Developer overview](../developer/overview-developer.md#overview-developer-documentation).
 
+#### Deprecated APIs and API fields
+
 The following list of API endpoints and fields that have been marked for deprecation:
 
-#### Jobs and Pods API
+##### Jobs and Pods API
 
 | Deprecated | Replacement |
 | -- | -- |
@@ -139,14 +141,14 @@ The following list of API endpoints and fields that have been marked for depreca
 | https://app.run.ai/v1/k8s/clusters/{uuid}/jobs/{jobId}/pods | https://app.run.ai/api/v1/workloads/{workloadId}/pods |
 | https://app.run.ai/v1/k8s/clusters/{uuid}/pods | https://app.run.ai/api/v1/workloads/pods |
 
-#### Clusters API
+##### Clusters API
 | Deprecated | Replacement |
 | -- | -- |
 | https://app.run.ai/v1/k8s/clusters | https://app.run.ai/api/v1/workloads |
 | https://app.run.ai/v1/k8s/clusters/{uuid} | https://app.run.ai/api/v1/workloads/count |
 | https://app.run.ai/v1/k8s/clusters/{clusterUuid}/metrics | https://app.run.ai/api/v1/clusters/{clusterUuid}/metrics |
 
-#### Authorization and Authentication API
+##### Authorization and Authentication API
 
 | Deprecated | Replacement |
 | -- | -- |
@@ -166,7 +168,7 @@ The following list of API endpoints and fields that have been marked for depreca
 | https://app.run.ai/api/v1/authorization/access-rules - _scopeType_ field | Use _filterBy_ / _sortBy_ fields |
 | https://app.run.ai/api/v1/authorization/access-rules - _roleId_ field | Use _filterBy_ / _sortBy_ fields |
 
-#### Projects API
+##### Projects API
 
 | Deprecated | Replacement |
 | -- | -- |
@@ -176,7 +178,7 @@ The following list of API endpoints and fields that have been marked for depreca
 | https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
 | https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _gpuOverQuotaWeight_ field | Use _nodePoolResources_ field |
 
-#### Departments API
+##### Departments API
 
 | Deprecated | Replacement |
 | -- | -- |
@@ -185,12 +187,22 @@ The following list of API endpoints and fields that have been marked for depreca
 | https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _allowOverQuota_ field | Use _nodePoolResources_ field |
 | https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
 
-#### Policy API
+##### Policy API
 
 | Deprecated | Replacement |
 | -- | -- |
 | https://app.run.ai/api/v1/policy/workspace | https://app.run.ai/api/v2/policy/workspaces |
 | https://app.run.ai/api/v1/policy/training | https://app.run.ai/api/v2/policy/trainings |
+
+#### Removed APIs and API fields (completed deprecation)
+
+The following list of API endpoints and fields that have completed their deprecation process and therefore will be changed as follows:
+
+##### Assets API
+
+| Endpoint | Change |
+| -- | -- |
+| https://app.run.ai/api/v1/asset/compute |  |
 
 ## Breaking changes
 

--- a/docs/home/whats-new-2-17.md
+++ b/docs/home/whats-new-2-17.md
@@ -142,10 +142,11 @@ The following list of API endpoints and fields that have been marked for depreca
 | https://app.run.ai/v1/k8s/clusters/{uuid}/pods | https://app.run.ai/api/v1/workloads/pods |
 
 ##### Clusters API
+
 | Deprecated | Replacement |
 | -- | -- |
-| https://app.run.ai/v1/k8s/clusters | https://app.run.ai/api/v1/workloads |
-| https://app.run.ai/v1/k8s/clusters/{uuid} | https://app.run.ai/api/v1/workloads/count |
+| https://app.run.ai/v1/k8s/clusters | https://app.run.ai/api/v1/clusters |
+| https://app.run.ai/v1/k8s/clusters/{uuid} | https://app.run.ai/api/v1/clusters/{uuid} |
 | https://app.run.ai/v1/k8s/clusters/{clusterUuid}/metrics | https://app.run.ai/api/v1/clusters/{clusterUuid}/metrics |
 
 ##### Authorization and Authentication API

--- a/docs/home/whats-new-2-17.md
+++ b/docs/home/whats-new-2-17.md
@@ -203,6 +203,26 @@ The following list of API endpoints and fields that have completed their depreca
 | -- | -- |
 | /api/v1/asset/compute | _gpuRequest_ field was removed and is replaced by the following fields _gpuDevicesRequest_, _gpuRequestType_, _gpuPortionRequest_, _gpuPortionLimit_, _gpuMemoryRequest_, _gpuMemoryLimit_, _migProfile_ |
 
+### Metrics deprecations
+
+The following metrics are deprecated and replaced by API. For details about the replacement APIs, see [Changed Metrics](../developer/metrics/metrics.md#changed-metrics-and-api-mapping):
+
+| Metric | 
+| -- |
+| runai\_active\_job\_cpu\_requested\_cores |
+| runai\_active\_job\_memory\_requested\_bytes |
+| runai\_cluster\_cpu\_utilization |
+| runai\_cluster\_memory\_utilization |
+| runai\_gpu\_utilization\_per\_pod\_per\_gpu |
+| runai\_gpu\_utilization\_per\_workload |
+| runai\_job\_requested\_gpu\_memory |
+| runai\_gpu\_memory\_used\_mebibytes\_per\_workload |
+| runai\_gpu\_memory\_used\_mebibytes\_per\_pod\_per\_gpu |
+| runai\_active\_job\_cpu\_limits |
+| runai\_job\_cpu\_usage |
+| runai\_active\_job\_memory\_limits |                                                                                       
+| runai\_job\_memory\_used\_bytes |
+
 ## Breaking changes
 
 Breaking changes notifications allow you to plan around potential changes that may interfere your current workflow when interfacing with the Run:ai Platform.

--- a/docs/home/whats-new-2-17.md
+++ b/docs/home/whats-new-2-17.md
@@ -136,64 +136,62 @@ The following list of API endpoints and fields that have been marked for depreca
 
 | Deprecated | Replacement |
 | -- | -- |
-| https://app.run.ai/v1/k8s/clusters/{uuid}/jobs | https://app.run.ai/api/v1/workloads |
-| https://app.run.ai/v1/k8s/clusters/{uuid}/jobs/count | https://app.run.ai/api/v1/workloads/count |
-| https://app.run.ai/v1/k8s/clusters/{uuid}/jobs/{jobId}/pods | https://app.run.ai/api/v1/workloads/{workloadId}/pods |
-| https://app.run.ai/v1/k8s/clusters/{uuid}/pods | https://app.run.ai/api/v1/workloads/pods |
+| /v1/k8s/clusters/{uuid}/jobs | /api/v1/workloads |
+| /v1/k8s/clusters/{uuid}/jobs/count | /api/v1/workloads/count |
+| /v1/k8s/clusters/{uuid}/jobs/{jobId}/pods | /api/v1/workloads/{workloadId}/pods |
+| /v1/k8s/clusters/{uuid}/pods | /api/v1/workloads/pods |
 
 ##### Clusters API
 
 | Deprecated | Replacement |
 | -- | -- |
-| https://app.run.ai/v1/k8s/clusters | https://app.run.ai/api/v1/clusters |
-| https://app.run.ai/v1/k8s/clusters/{uuid} | https://app.run.ai/api/v1/clusters/{uuid} |
-| https://app.run.ai/v1/k8s/clusters/{clusterUuid}/metrics | https://app.run.ai/api/v1/clusters/{clusterUuid}/metrics |
+| /v1/k8s/clusters/{clusterUuid}/metrics | /api/v1/clusters/{clusterUuid}/metrics |
 
 ##### Authorization and Authentication API
 
 | Deprecated | Replacement |
 | -- | -- |
-| https://app.run.ai/v1/k8s/auth/token/exchange | https://app.run.ai/api/v1/token |
-| https://app.run.ai/v1/k8s/auth/oauth/tokens/refresh | https://app.run.ai/api/v1/token |
-| https://app.run.ai/v1/k8s/auth/oauth/apptoken | https://app.run.ai/api/v1/token |
-| https://app.run.ai/v1/k8s/users/roles | https://app.run.ai/api/v1/authorization/roles |
-| https://app.run.ai/v1/k8s/users | https://app.run.ai/api/v1/users |
-| https://app.run.ai/v1/k8s/users/{userId} | https://app.run.ai/api/v1/users/{userId} |
-| https://app.run.ai/v1/k8s/users/{userId}/roles | https://app.run.ai/api/v1/authorization/access-rules |
-| https://app.run.ai/v1/k8s/apps | https://app.run.ai/api/v1/apps |
-| https://app.run.ai/v1/k8s/apps/{clientId} | https://app.run.ai/api/v1/apps/{appId} |
-| https://app.run.ai/v1/k8s/groups | https://app.run.ai/api/v1/authorization/access-rules |
-| https://app.run.ai/v1/k8s/groups/{groupName} | https://app.run.ai/api/v1/authorization/access-rules |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/departments/{department-id}/access-control | https://app.run.ai/api/v1/authorization/access-rules |
-| https://app.run.ai/api/v1/authorization/access-rules - _subjectIdFilter_ field | Use _filterBy_ / _sortBy_ fields |
-| https://app.run.ai/api/v1/authorization/access-rules - _scopeType_ field | Use _filterBy_ / _sortBy_ fields |
-| https://app.run.ai/api/v1/authorization/access-rules - _roleId_ field | Use _filterBy_ / _sortBy_ fields |
+| /v1/k8s/auth/token/exchange | /api/v1/token |
+| /v1/k8s/auth/oauth/tokens/refresh | /api/v1/token |
+| /v1/k8s/auth/oauth/apptoken | /api/v1/token |
+| /v1/k8s/users/roles | /api/v1/authorization/roles |
+| /v1/k8s/users | /api/v1/users |
+| /v1/k8s/users/{userId} | /api/v1/users/{userId} |
+| /v1/k8s/users/{userId}/roles | /api/v1/authorization/access-rules |
+| /v1/k8s/apps | /api/v1/apps |
+| /v1/k8s/apps/{clientId} | /api/v1/apps/{appId} |
+| /v1/k8s/groups | /api/v1/authorization/access-rules |
+| /v1/k8s/groups/{groupName} | /api/v1/authorization/access-rules |
+| /v1/k8s/clusters/{clusterId}/departments/{department-id}/access-control | /api/v1/authorization/access-rules |
+| /api/v1/authorization/access-rules - _subjectIdFilter_ field | Use _filterBy_ / _sortBy_ fields |
+| /api/v1/authorization/access-rules - _scopeType_ field | Use _filterBy_ / _sortBy_ fields |
+| /api/v1/authorization/access-rules - _roleId_ field | Use _filterBy_ / _sortBy_ fields |
 
 ##### Projects API
 
 | Deprecated | Replacement |
 | -- | -- |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _permissions_ field | https://app.run.ai/api/v1/authorization/access-rules |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _resources_ field | Use _nodePoolResources_ field |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _deservedGpus_ field | Use _nodePoolResources_ field |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _gpuOverQuotaWeight_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/projects - _permissions_ field | /api/v1/authorization/access-rules |
+| /v1/k8s/clusters/{clusterId}/projects - _resources_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/projects - _deservedGpus_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/projects - _gpuOverQuotaWeight_ field | Use _nodePoolResources_ field |
 
 ##### Departments API
 
 | Deprecated | Replacement |
 | -- | -- |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _resources_ field | Use _nodePoolResources_ field |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _deservedGpus_ field | Use _nodePoolResources_ field |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _allowOverQuota_ field | Use _nodePoolResources_ field |
-| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/projects - _resources_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/projects - _deservedGpus_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/projects - _allowOverQuota_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
 
 ##### Policy API
 
 | Deprecated | Replacement |
 | -- | -- |
-| https://app.run.ai/api/v1/policy/workspace | https://app.run.ai/api/v2/policy/workspaces |
-| https://app.run.ai/api/v1/policy/training | https://app.run.ai/api/v2/policy/trainings |
+| /api/v1/policy/workspace | /api/v2/policy/workspaces |
+| /api/v1/policy/training | /api/v2/policy/trainings |
 
 #### Removed APIs and API fields (completed deprecation)
 
@@ -203,7 +201,7 @@ The following list of API endpoints and fields that have completed their depreca
 
 | Endpoint | Change |
 | -- | -- |
-| https://app.run.ai/api/v1/asset/compute | _gpuRequest_ field was removed and is replaced by the following fields _gpuDevicesRequest_, _gpuRequestType_, _gpuPortionRequest_, _gpuPortionLimit_, _gpuMemoryRequest_, _gpuMemoryLimit_, _migProfile_ |
+| /api/v1/asset/compute | _gpuRequest_ field was removed and is replaced by the following fields _gpuDevicesRequest_, _gpuRequestType_, _gpuPortionRequest_, _gpuPortionLimit_, _gpuMemoryRequest_, _gpuMemoryLimit_, _migProfile_ |
 
 ## Breaking changes
 

--- a/docs/home/whats-new-2-17.md
+++ b/docs/home/whats-new-2-17.md
@@ -181,10 +181,10 @@ The following list of API endpoints and fields that have been marked for depreca
 
 | Deprecated | Replacement |
 | -- | -- |
-| /v1/k8s/clusters/{clusterId}/projects - _resources_ field | Use _nodePoolResources_ field |
-| /v1/k8s/clusters/{clusterId}/projects - _deservedGpus_ field | Use _nodePoolResources_ field |
-| /v1/k8s/clusters/{clusterId}/projects - _allowOverQuota_ field | Use _nodePoolResources_ field |
-| /v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/departments - _resources_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/departments - _deservedGpus_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/departments - _allowOverQuota_ field | Use _nodePoolResources_ field |
+| /v1/k8s/clusters/{clusterId}/departments - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
 
 ##### Policy API
 

--- a/docs/home/whats-new-2-17.md
+++ b/docs/home/whats-new-2-17.md
@@ -202,7 +202,7 @@ The following list of API endpoints and fields that have completed their depreca
 
 | Endpoint | Change |
 | -- | -- |
-| https://app.run.ai/api/v1/asset/compute |  |
+| https://app.run.ai/api/v1/asset/compute | _gpuRequest_ field was removed and is replaced by the following fields _gpuDevicesRequest_, _gpuRequestType_, _gpuPortionRequest_, _gpuPortionLimit_, _gpuMemoryRequest_, _gpuMemoryLimit_, _migProfile_ |
 
 ## Breaking changes
 

--- a/docs/home/whats-new-2-17.md
+++ b/docs/home/whats-new-2-17.md
@@ -128,30 +128,69 @@ Deprecated features will be available for **two** versions ahead of the notifica
 
 The endpoints and parameters specified in the API reference are the ones that are officially supported by Run:ai. For more information about Run:ai's API support policy and deprecation process, see [Developer overview](../developer/overview-developer.md#overview-developer-documentation).
 
-The following list of API endpoints have been marked for deprecation:
+The following list of API endpoints and fields that have been marked for deprecation:
 
-#### Jobs, events, pods API (replaced by workloads/pods/events)
+#### Jobs and Pods API
 
-| Deprecated endpoint | Replacement endpoint |
+| Deprecated | Replacement |
 | -- | -- |
 | https://app.run.ai/v1/k8s/clusters/{uuid}/jobs | https://app.run.ai/api/v1/workloads |
 | https://app.run.ai/v1/k8s/clusters/{uuid}/jobs/count | https://app.run.ai/api/v1/workloads/count |
 | https://app.run.ai/v1/k8s/clusters/{uuid}/jobs/{jobId}/pods | https://app.run.ai/api/v1/workloads/{workloadId}/pods |
 | https://app.run.ai/v1/k8s/clusters/{uuid}/pods | https://app.run.ai/api/v1/workloads/pods |
 
-#### Users, Applications, and Groups API
-
-| Deprecated endpoint | Replacement endpoint |
+#### Clusters API
+| Deprecated | Replacement |
 | -- | -- |
-| https://app.run.ai/v1/k8s/apps | https://app.run.ai/api/v1/k8s/apps |
-| https://app.run.ai/v1/k8s/users | https://app.run.ai/api/v1/k8s/users |
-| https://app.run.ai/v1/k8s/groups | https://app.run.ai/api/v1/authorization/access-rules (groups should no longer be created, you can only add access rules to them) |
+| https://app.run.ai/v1/k8s/clusters | https://app.run.ai/api/v1/workloads |
+| https://app.run.ai/v1/k8s/clusters/{uuid} | https://app.run.ai/api/v1/workloads/count |
+| https://app.run.ai/v1/k8s/clusters/{clusterUuid}/metrics | https://app.run.ai/api/v1/clusters/{clusterUuid}/metrics |
 
-#### Cluster metrics v1 (replaced by v2)
+#### Authorization and Authentication API
 
-| Deprecated endpoint | Replacement endpoint |
+| Deprecated | Replacement |
 | -- | -- |
-| https://app.run.ai/v1/k8s/clusters/{clusterUuid}/metrics | https://app.run.ai/api/v2/clusters/{clusterUuid}/metrics |
+| https://app.run.ai/v1/k8s/auth/token/exchange | https://app.run.ai/api/v1/token |
+| https://app.run.ai/v1/k8s/auth/oauth/tokens/refresh | https://app.run.ai/api/v1/token |
+| https://app.run.ai/v1/k8s/auth/oauth/apptoken | https://app.run.ai/api/v1/token |
+| https://app.run.ai/v1/k8s/users/roles | https://app.run.ai/api/v1/authorization/roles |
+| https://app.run.ai/v1/k8s/users | https://app.run.ai/api/v1/users |
+| https://app.run.ai/v1/k8s/users/{userId} | https://app.run.ai/api/v1/users/{userId} |
+| https://app.run.ai/v1/k8s/users/{userId}/roles | https://app.run.ai/api/v1/authorization/access-rules |
+| https://app.run.ai/v1/k8s/apps | https://app.run.ai/api/v1/apps |
+| https://app.run.ai/v1/k8s/apps/{clientId} | https://app.run.ai/api/v1/apps/{appId} |
+| https://app.run.ai/v1/k8s/groups | https://app.run.ai/api/v1/authorization/access-rules |
+| https://app.run.ai/v1/k8s/groups/{groupName} | https://app.run.ai/api/v1/authorization/access-rules |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/departments/{department-id}/access-control | https://app.run.ai/api/v1/authorization/access-rules |
+| https://app.run.ai/api/v1/authorization/access-rules - _subjectIdFilter_ field | Use _filterBy_ / _sortBy_ fields |
+| https://app.run.ai/api/v1/authorization/access-rules - _scopeType_ field | Use _filterBy_ / _sortBy_ fields |
+| https://app.run.ai/api/v1/authorization/access-rules - _roleId_ field | Use _filterBy_ / _sortBy_ fields |
+
+#### Projects API
+
+| Deprecated | Replacement |
+| -- | -- |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _permissions_ field | https://app.run.ai/api/v1/authorization/access-rules |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _resources_ field | Use _nodePoolResources_ field |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _deservedGpus_ field | Use _nodePoolResources_ field |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _gpuOverQuotaWeight_ field | Use _nodePoolResources_ field |
+
+#### Departments API
+
+| Deprecated | Replacement |
+| -- | -- |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _resources_ field | Use _nodePoolResources_ field |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _deservedGpus_ field | Use _nodePoolResources_ field |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _allowOverQuota_ field | Use _nodePoolResources_ field |
+| https://app.run.ai/v1/k8s/clusters/{clusterId}/projects - _maxAllowedGpus_ field | Use _nodePoolResources_ field |
+
+#### Policy API
+
+| Deprecated | Replacement |
+| -- | -- |
+| https://app.run.ai/api/v1/policy/workspace | https://app.run.ai/api/v2/policy/workspaces |
+| https://app.run.ai/api/v1/policy/training | https://app.run.ai/api/v2/policy/trainings |
 
 ## Breaking changes
 

--- a/docs/home/whats-new-2-17.md
+++ b/docs/home/whats-new-2-17.md
@@ -205,7 +205,7 @@ The following list of API endpoints and fields that have completed their depreca
 
 ### Metrics deprecations
 
-The following metrics are deprecated and replaced by API. For details about the replacement APIs, see [Changed Metrics](../developer/metrics/metrics.md#changed-metrics-and-api-mapping):
+The following metrics are deprecated and replaced by API endpoints. For details about the replacement APIs, see [Changed Metrics](../developer/metrics/metrics.md#changed-metrics-and-api-mapping):
 
 | Metric |
 | -- |


### PR DESCRIPTION
Still missing decision about the clusters API and how to handle them. Currently, they are on the deprecation section