### PR TITLE
Policy doc219 updates

### DIFF
--- a/docs/platform-admin/workloads/assets/environments.md
+++ b/docs/platform-admin/workloads/assets/environments.md
@@ -123,7 +123,7 @@ To add a new environment:
 13. Optional: __Set the environment variable(s)__  
     * The environment variable(s) are added to the default environment variables that are already set within the image  
     * The environment variables can be modified and new variables can be added while submitting a workload using the environment
-    * You can configure a new Environment variable from your credentials (of type generic secret, access key or username & password). When selecting an environment variable source from credentials - the predefined credentials name in the system and the available key types are displayed as an option.  
+    * You can configure a new Environment variable from your credentials (of type generic secret, access key or username & password). When selecting an environment variable source from credentials, the predefined name for the credential assets are displayed as an option. In addition, you can select the type of the credential to be used (username / password or access key / access secret).
 14. Optional: Set the container’s __working directory__ to define where the container’s process starts running. When left empty, the default directory is used.  
 15. Optional: Set where the UID, GID and supplementary groups are taken from, this can be:  
     * __From the image__  

--- a/docs/platform-admin/workloads/policies/overview.md
+++ b/docs/platform-admin/workloads/policies/overview.md
@@ -89,15 +89,15 @@ The different scoping of policies also allows the breakdown of the responsibilit
 
 #### Policy rules reconciliation
 
-For situations where a rule or a default for a specific field is already occupied by a policy in the organization, we have introduced a reonciliation mechanism. The mechanism works as follows:
+For situations where a rule or a default for a specific field is already governed by a policy, newly submitted policies for additional organizational units mentioning this existing field are not blocked from submission. For those instances, the effective rules and defaults are selected based on the following logic:
 
-* For rules and defaults - If the rule is already occupied by a previous policy, the new policy submission is not blocked.
-* For defaults - The lowest hierarchy “closest” to the actual workload wins (projects defaults > department defaults > cluster defaults > tenants defaults).
-* For rules:
-  * If the rule belongs to the group of computatation resources or security rules - the highest hierarchy wins (tenant rules > cluster rules > department rules > project rules).
-  * If the rule does not belong to the group of computation resources or security rules - the lowest hierarchy “closest” to the actual workload wins (similar to defaults).
+* For policy defaults - The lowest organizational hierarchy “closest” to the actual workload becomes the effective policy defaults (project defaults > department defaults > cluster defaults > tenant defaults).
+* For policy rules - 
+  * If the rule belongs to the compute and security sections in the workload spec of the Run:ai API, the highest hierarchy is chosen for the effective policy for the field (tenant rules > cluster rules > department rules > project rules).
+  * If the rule does not belong to the compute or security sections, the lowest hierarchy “closest” to the actual workload becomes the effective policy for the field (similar to defaults).
 
-While viewing the policy, for each rule and default the source of the rule is visible, allowing the user to understand the hierarchy of the effective policy.
+While viewing the effective policy, for each rule and default the source of the policy origin is visible, allowing users to clearly understand the selected hierarchy of the effective policy.
+
 
 ## Run:ai Policies vs. Kyverno Policies
 

--- a/docs/platform-admin/workloads/policies/policy-reference.md
+++ b/docs/platform-admin/workloads/policies/policy-reference.md
@@ -31,7 +31,6 @@ Click the link to view the value type of each field.
 | PodAffinitySchedulingRule | Indicates if we want to use the Pod affinity rule as: the “hard” (required) or the “soft” (preferred) option. This field can be specified only if PodAffinity is set to true. | string | Workspace Training |
 | podAffinityTopology | Specifies the Pod Affinity Topology to be used for scheduling the job. This field can be specified only if PodAffinity is set to true. | string | Workspace Training |
 | ports | Specifies a set of ports exposed from the container running the created workload. More information in Ports fields below. | itemized | Workspace Training |
-| preemptible | Specifies that the created workload is preemptible. Interactive preemptible workloads can be scheduled above the guaranteed quota but may be reclaimed at any time. | boolean | Workspace |
 | probes | Specifies the ReadinessProbe to use to determine if the container is ready to accept traffic. More information in Probes fields below | - | Workspace Training |
 | tolerations | Toleration rules which apply to the pods running the workload. Toleration rules guide (but do not require) the system to which node each pod can be scheduled to or evicted from, based on matching between those rules and the set of taints defined for each Kubernetes node. | itemized | Workspace Training |
 | storage | Contains all the fields related to storage configurations. More information in Storage fields below. | - | Workspace Training |


### PR DESCRIPTION
3 fixes - 

1. remove field from policy spec (a field that was added as a mistake)
2. changed policy reconciliation paragraph based on the new "what's new 2.19"
3. changed new environment variable addition based on the new "what's new 2.19"